### PR TITLE
Model 1.2 implementation

### DIFF
--- a/src/vivarium_gates_nutrition_optimization/components/children.py
+++ b/src/vivarium_gates_nutrition_optimization/components/children.py
@@ -28,7 +28,7 @@ class NewChildren:
 
     @property
     def columns_created(self):
-        return ["sex_of_child", "birth_weight", "gestational_age"]
+        return ["sex_of_child", "birth_weight"]
 
     def setup(self, builder: Builder):
         self.randomness = builder.randomness.get_stream(self.name)
@@ -41,12 +41,11 @@ class NewChildren:
             {
                 "sex_of_child": models.INVALID_OUTCOME,
                 "birth_weight": np.nan,
-                "gestational_age": np.nan,
             },
             index=index,
         )
 
-    def __call__(self, index: pd.Index):
+    def generate_children(self, index: pd.Index):
         sex_of_child = self.randomness.choice(
             index,
             choices=["Male", "Female"],

--- a/src/vivarium_gates_nutrition_optimization/components/children.py
+++ b/src/vivarium_gates_nutrition_optimization/components/children.py
@@ -1,13 +1,124 @@
+from typing import Tuple
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium_cluster_tools.utilities import mkdir
 
-from vivarium_gates_nutrition_optimization.constants import models
+from vivarium_gates_nutrition_optimization.constants import models, data_keys
+
+class NewChildren:
+
+    def __init__(self):
+        self.lbwsg = LBWSGDistribution()
+
+    @property
+    def name(self):
+        return 'child_status'
+
+    @property
+    def sub_components(self):
+        return [self.lbwsg]
+
+    @property
+    def columns_created(self):
+        return ['sex_of_child', 'birth_weight', 'gestational_age']
+
+    def setup(self, builder: Builder):
+        self.randomness = builder.randomness.get_stream(self.name)
+
+    def empty(self, index: pd.Index) -> pd.DataFrame:
+        return pd.DataFrame({
+            'sex_of_child': models.INVALID_OUTCOME,
+            'birth_weight': np.nan,
+            'gestational_age': np.nan,
+        }, index=index)
+
+    def __call__(self, index: pd.Index):
+        sex_of_child = self.randomness.choice(
+            index,
+            choices=['Male', 'Female'],
+            additional_key='sex_of_child',
+        )
+        lbwsg = self.lbwsg(sex_of_child)
+        return pd.DataFrame({
+            'sex_of_child': sex_of_child,
+            'birth_weight': lbwsg['birth_weight'],
+            'gestational_age': lbwsg['gestational_age'],
+        }, index=index)
 
 
+class LBWSGDistribution:
+
+    @property
+    def name(self):
+        return 'lbwsg_distribution'
+
+    def setup(self, builder: Builder):
+        self.randomness = builder.randomness.get_stream(self.name)
+        self.exposure = builder.data.load(data_keys.LBWSG.EXPOSURE).set_index('sex')
+        self.category_intervals = self._get_category_intervals(builder)
+
+    def __call__(self, newborn_sex: pd.Series):
+        categorical_exposure = self._sample_categorical_exposure(newborn_sex)
+        continuous_exposure = self._sample_continuous_exposure(categorical_exposure)
+        return continuous_exposure
+
+    ############
+    # Sampling #
+    ############
+
+    def _sample_categorical_exposure(self, newborn_sex: pd.Series):
+        categorical_exposures = []
+        for sex in newborn_sex.unique():
+            group_data = newborn_sex[newborn_sex == sex]
+            sex_exposure = self.exposure.loc[sex]
+            categorical_exposures.append(self.randomness.choice(
+                group_data.index,
+                choices=sex_exposure.parameter.tolist(),
+                p=sex_exposure.value.tolist(),
+                additional_key='categorical_exposure',
+            ))
+        categorical_exposures = pd.concat(categorical_exposures).sort_index()
+        return categorical_exposures
+
+    def _sample_continuous_exposure(self, categorical_exposure: pd.Series):
+        intervals = self.category_intervals.loc[categorical_exposure]
+        intervals.index = categorical_exposure.index
+        exposures = []
+        for axis in ['birth_weight', 'gestational_age']:
+            draw = self.randomness.get_draw(categorical_exposure.index, additional_key=axis)
+            lower, upper = intervals[f'{axis}_lower'], intervals[f'{axis}_upper']
+            exposures.append((lower + (upper - lower) * draw).rename(axis))
+        return pd.concat(exposures, axis=1)
+
+    ################
+    # Data loading #
+    ################
+
+    def _get_category_intervals(self, builder: Builder):
+        categories = builder.data.load(data_keys.LBWSG.CATEGORIES)
+        category_intervals = pd.DataFrame(
+            data=[(category, *self._parse_description(description))
+                  for category, description in categories.items()],
+            columns=['category',
+                     'birth_weight_lower', 'birth_weight_upper',
+                     'gestational_age_lower', 'gestational_age_upper'],
+        ).set_index('category')
+        return category_intervals
+
+    @staticmethod
+    def _parse_description(description: str) -> Tuple:
+        birth_weight = [
+            float(val) for val in description.split(", [")[1].split(")")[0].split(", ")
+        ]
+        gestational_age = [
+            float(val) for val in description.split("- [")[1].split(")")[0].split(", ")
+        ]
+        return *birth_weight, *gestational_age
+    
 class BirthRecorder:
     @property
     def name(self):

--- a/src/vivarium_gates_nutrition_optimization/components/children.py
+++ b/src/vivarium_gates_nutrition_optimization/components/children.py
@@ -47,16 +47,10 @@ class NewChildren:
         )
 
     def __call__(self, index: pd.Index):
-        sex_probabilities = pd.DataFrame(
-            {
-                "Male": self.male_sex_percentage,
-                "Female": 1 - self.male_sex_percentage,
-            }
-        )
         sex_of_child = self.randomness.choice(
             index,
             choices=["Male", "Female"],
-            p=sex_probabilities,
+            p=[self.male_sex_percentage, 1-self.male_sex_percentage],
             additional_key="sex_of_child",
         )
         lbwsg = self.lbwsg(sex_of_child)

--- a/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
+++ b/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
@@ -100,11 +100,11 @@ class PregnantState(DiseaseState):
         return child_status
 
     def sample_full_term_durations(self, full_term_pop: pd.Index) -> pd.DataFrame:
-        child_status = self.new_children(full_term_pop)
+        child_status = self.new_children.generate_children(full_term_pop)
         child_status["pregnancy_duration"] = pd.to_timedelta(
             7 * child_status["gestational_age"], unit="days"
         )
-        return child_status
+        return child_status.drop(columns=["gestational_age"])
 
     def get_dwell_time_pipeline(self, builder: Builder) -> Pipeline:
         return builder.value.register_value_producer(

--- a/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
+++ b/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
@@ -4,6 +4,7 @@ from vivarium.framework.population import SimulantData
 from vivarium.framework.values import Pipeline
 from vivarium_public_health.disease import DiseaseModel, SusceptibleState
 
+from vivarium_gates_nutrition_optimization.children import NewChildren
 from vivarium_gates_nutrition_optimization.components.disease import DiseaseState
 from vivarium_gates_nutrition_optimization.constants import data_keys, models
 from vivarium_gates_nutrition_optimization.constants.data_values import DURATIONS
@@ -18,6 +19,9 @@ class NotPregnantState(SusceptibleState):
 
 
 class PregnantState(DiseaseState):
+    def __init__(self):
+        super().__init__()
+        self.new_children = NewChildren
     @property
     def columns_created(self):
         return [
@@ -25,6 +29,7 @@ class PregnantState(DiseaseState):
             self.event_count_column,
             "pregnancy_outcome",
             "pregnancy_duration",
+            + self.new_children.columns_created
         ]
 
     def setup(self, builder: Builder):

--- a/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
+++ b/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
@@ -22,11 +22,8 @@ class PregnantState(DiseaseState):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.new_children = NewChildren()
-
-    @property
-    def sub_components(self):
-        return [self.new_children]
-
+        self._sub_components += [self.new_children]
+        
     @property
     def columns_created(self):
         return [

--- a/src/vivarium_gates_nutrition_optimization/constants/data_values.py
+++ b/src/vivarium_gates_nutrition_optimization/constants/data_values.py
@@ -13,3 +13,9 @@ class _Durations(NamedTuple):
 
 
 DURATIONS = _Durations()
+
+INFANT_MALE_PERCENTAGES = {
+    "Ethiopia": 0.514271,
+    "Nigeria": 0.511785,
+    "Pakistan": 0.514583,
+}

--- a/src/vivarium_gates_nutrition_optimization/constants/models.py
+++ b/src/vivarium_gates_nutrition_optimization/constants/models.py
@@ -29,6 +29,7 @@ PREGNANCY_MODEL_TRANSITIONS = (
 PARTIAL_TERM_OUTCOME = "partial_term"
 LIVE_BIRTH_OUTCOME = "live_birth"
 STILLBIRTH_OUTCOME = "stillbirth"
+INVALID_OUTCOME = "invalid" ## For sex of partial births
 
 PREGNANCY_OUTCOMES = (
     PARTIAL_TERM_OUTCOME,

--- a/src/vivarium_gates_nutrition_optimization/constants/models.py
+++ b/src/vivarium_gates_nutrition_optimization/constants/models.py
@@ -29,7 +29,7 @@ PREGNANCY_MODEL_TRANSITIONS = (
 PARTIAL_TERM_OUTCOME = "partial_term"
 LIVE_BIRTH_OUTCOME = "live_birth"
 STILLBIRTH_OUTCOME = "stillbirth"
-INVALID_OUTCOME = "invalid" ## For sex of partial births
+INVALID_OUTCOME = "invalid"  ## For sex of partial births
 
 PREGNANCY_OUTCOMES = (
     PARTIAL_TERM_OUTCOME,


### PR DESCRIPTION
## Model 1.2 implementation
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> Implementation
- *JIRA issue*: [MIC-4183](https://jira.ihme.washington.edu/browse/MIC-4183)
- *Research reference*: <!--Link to research documentation for code -->
[Pregnancy Model](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_nutrition_optimization/pregnancies/concept_model.html#models)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
I did the following:

- Determine infant sex at birth according to constant probability specifed by RT
- add birth weight and gestational age to child model (basically ripped from IV Iron)
- use LBWSG gestational age exposure to determine pregnancy duration

I decided to keep both gestational age and pregnancy duration, even though they are mostly the same--my reasoning was that

1. Calling the LBWSG exposure located in the child model a 'pregnancy duration' improperly ascribes a property of pregnancy to the child
2. By our use of terms, partial births do not have an infant sex or a gestational age

If we don't really care about the distinction, it would be simpler to just collapse the two into either one or the other, and either just be fine with the fact we're giving partial births gestational ages, or be fine with defining the pregnancy duration in the child model.
### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
CI passing; birthweight, gestational age, sex of child, pregnancy duration are filled into state table with reasonable proportions.
