### PR TITLE
Model1.2 Observers

### DIFF
--- a/src/vivarium_gates_nutrition_optimization/components/__init__.py
+++ b/src/vivarium_gates_nutrition_optimization/components/__init__.py
@@ -1,3 +1,3 @@
 from .children import BirthRecorder
-from .observers import PregnancyObserver
+from .observers import PregnancyObserver, ResultsStratifier
 from .pregnancy import Pregnancy

--- a/src/vivarium_gates_nutrition_optimization/components/children.py
+++ b/src/vivarium_gates_nutrition_optimization/components/children.py
@@ -49,7 +49,7 @@ class NewChildren:
         sex_of_child = self.randomness.choice(
             index,
             choices=["Male", "Female"],
-            p=[self.male_sex_percentage, 1-self.male_sex_percentage],
+            p=[self.male_sex_percentage, 1 - self.male_sex_percentage],
             additional_key="sex_of_child",
         )
         lbwsg = self.lbwsg(sex_of_child)
@@ -179,7 +179,9 @@ class BirthRecorder:
             & (pop["pregnancy"] == models.POSTPARTUM_STATE_NAME)
         )
 
-        new_births = pop.loc[new_birth_mask, ["pregnancy_duration"]]
+        new_births = pop.loc[new_birth_mask, ["pregnancy_duration", "birth_weight"]].rename(
+            columns={"pregnancy_duration": "gestational_age"}
+        )
 
         self.births.append(new_births)
 

--- a/src/vivarium_gates_nutrition_optimization/components/children.py
+++ b/src/vivarium_gates_nutrition_optimization/components/children.py
@@ -159,6 +159,7 @@ class BirthRecorder:
         required_columns = [
             "pregnancy_outcome",
             "pregnancy_duration",
+            "birth_weight",
             "pregnancy",
             "previous_pregnancy",
         ]

--- a/src/vivarium_gates_nutrition_optimization/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization/components/observers.py
@@ -49,12 +49,11 @@ class PregnancyObserver(DiseaseObserver):
                 )
                 new_observations[key] = transition_mask.sum()
 
-                key = f"birth_count_{label}"
-                term_mask = (
-                    group_mask
-                    & (pop[self.previous_state_column_name] == models.PREGNANT_STATE_NAME)
-                    & (pop[self.current_state_column_name] == models.POSTPARTUM_STATE_NAME)
-                )
-                new_observations[key] = term_mask.sum()
+                # add separate birth outcome counts
+                if (
+                    transition.from_state == models.PREGNANT_STATE_NAME
+                    and transition.to_state == models.POSTPARTUM_STATE_NAME
+                ):
+                    new_observations[f"birth_count_{label}"] = transition_mask.sum()
 
         self.counts.update(new_observations)

--- a/src/vivarium_gates_nutrition_optimization/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization/components/observers.py
@@ -32,21 +32,3 @@ class PregnancyObserver(DiseaseObserver):
             "pregnancy_outcome",
         ]
         return builder.population.get_view(columns_required)
-
-    # def on_collect_metrics(self, event: Event) -> None:
-    #     pop = self.population_view.get(
-    #         event.index, query='tracked == True and alive == "alive"'
-    #     )
-    #     new_observations = {}
-    #     groups = self.stratifier.group(pop.index, self.config.include, self.config.exclude)
-    #     for label, group_mask in groups:
-    #         for transition in self.transitions:
-    #             key = f"{self.disease}_{transition}_event_count_{label}"
-    #             transition_mask = (
-    #                 group_mask
-    #                 & (pop[self.previous_state_column_name] == transition.from_state)
-    #                 & (pop[self.current_state_column_name] == transition.to_state)
-    #             )
-    #             new_observations[key] = transition_mask.sum()
-
-    #     self.counts.update(new_observations)

--- a/src/vivarium_gates_nutrition_optimization/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization/components/observers.py
@@ -1,11 +1,13 @@
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import PopulationView
-from vivarium_public_health.metrics import DiseaseObserver, ResultsStratifier as ResultsStratifier_
-from vivarium_public_health.utilities import to_years
+from vivarium_public_health.metrics import DiseaseObserver
+from vivarium_public_health.metrics import ResultsStratifier as ResultsStratifier_
 from vivarium_public_health.metrics.stratification import Source, SourceType
+from vivarium_public_health.utilities import to_years
 
 from vivarium_gates_nutrition_optimization.constants import models
+
 
 class ResultsStratifier(ResultsStratifier_):
     def register_stratifications(self, builder: Builder) -> None:
@@ -13,10 +15,11 @@ class ResultsStratifier(ResultsStratifier_):
 
         self.setup_stratification(
             builder,
-            name='pregnancy_outcome',
-            sources=[Source('pregnancy_outcome', SourceType.COLUMN)],
+            name="pregnancy_outcome",
+            sources=[Source("pregnancy_outcome", SourceType.COLUMN)],
             categories=models.PREGNANCY_OUTCOMES,
         )
+
 
 class PregnancyObserver(DiseaseObserver):
     def __init__(self):

--- a/src/vivarium_gates_nutrition_optimization/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization/components/observers.py
@@ -33,27 +33,20 @@ class PregnancyObserver(DiseaseObserver):
         ]
         return builder.population.get_view(columns_required)
 
-    def on_collect_metrics(self, event: Event) -> None:
-        pop = self.population_view.get(
-            event.index, query='tracked == True and alive == "alive"'
-        )
-        new_observations = {}
-        groups = self.stratifier.group(pop.index, self.config.include, self.config.exclude)
-        for label, group_mask in groups:
-            for transition in self.transitions:
-                key = f"{self.disease}_{transition}_event_count_{label}"
-                transition_mask = (
-                    group_mask
-                    & (pop[self.previous_state_column_name] == transition.from_state)
-                    & (pop[self.current_state_column_name] == transition.to_state)
-                )
-                new_observations[key] = transition_mask.sum()
+    # def on_collect_metrics(self, event: Event) -> None:
+    #     pop = self.population_view.get(
+    #         event.index, query='tracked == True and alive == "alive"'
+    #     )
+    #     new_observations = {}
+    #     groups = self.stratifier.group(pop.index, self.config.include, self.config.exclude)
+    #     for label, group_mask in groups:
+    #         for transition in self.transitions:
+    #             key = f"{self.disease}_{transition}_event_count_{label}"
+    #             transition_mask = (
+    #                 group_mask
+    #                 & (pop[self.previous_state_column_name] == transition.from_state)
+    #                 & (pop[self.current_state_column_name] == transition.to_state)
+    #             )
+    #             new_observations[key] = transition_mask.sum()
 
-                # add separate birth outcome counts
-                if (
-                    transition.from_state == models.PREGNANT_STATE_NAME
-                    and transition.to_state == models.POSTPARTUM_STATE_NAME
-                ):
-                    new_observations[f"birth_count_{label}"] = transition_mask.sum()
-
-        self.counts.update(new_observations)
+    #     self.counts.update(new_observations)

--- a/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
+++ b/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
@@ -23,7 +23,7 @@ class PregnantState(DiseaseState):
         super().__init__(*args, **kwargs)
         self.new_children = NewChildren()
         self._sub_components += [self.new_children]
-        
+
     @property
     def columns_created(self):
         return [

--- a/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
@@ -6,13 +6,13 @@ components:
         metrics:
 #            - DisabilityObserver()
             - MortalityObserver()
-            - ResultsStratifier()
 
     vivarium_gates_nutrition_optimization:
         components:
             - Pregnancy()
             - PregnancyObserver()
             - BirthRecorder()
+            - ResultsStratifier()
 
 configuration:
     input_data:
@@ -44,6 +44,9 @@ configuration:
     observers:
         default:
             - 'age'
+        pregnancy:
+            include:
+            - 'pregnancy_outcome'
         # disability:
         #     include:
         #     exclude:


### PR DESCRIPTION
## Title: Model 1.2 Observers
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> observers
- *JIRA issue*: [MIC-4184](https://jira.ihme.washington.edu/browse/MIC-4184)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
I added birth weight to child output, and stratified pregnancy state person time and transition counts by pregnancy outcome. I also modified the birth outcome counts given the new stratification.

Technically, the birth counts by outcome duplicates from the transitions, e.g.,
` 'pregnancy_pregnant_to_postpartum_event_count_age_75_to_79_pregnancy_outcome_partial_term': 0,`
and
` 'birth_count_age_75_to_79_pregnancy_outcome_partial_term'`
are the same. I did it this way because the model requirements specify both, and it might be easier to have the subset to validate. It's easy to remove if it is unnecessary.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

Metrics from interactive sim count the correct values and look appropriate in scale. CI passes.