### PR TITLE
Model 4.0 Observers

### DIFF
--- a/src/vivarium_gates_nutrition_optimization/components/hemoglobin.py
+++ b/src/vivarium_gates_nutrition_optimization/components/hemoglobin.py
@@ -305,7 +305,7 @@ class Anemia:
         choice_index = (hemoglobin_level.values[np.newaxis].T < thresholds).sum(axis=1)
 
         return pd.Series(
-            np.array(["none", "mild", "moderate", "severe"])[choice_index],
+            np.array(["not_anemic", "mild", "moderate", "severe"])[choice_index],
             index=index,
             name="anemia_levels",
         )
@@ -331,7 +331,7 @@ class Anemia:
         return disability_weight
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
-        pop_update = pd.DataFrame({"anemia_status_at_birth": "none"}, index=pop_data.index)
+        pop_update = pd.DataFrame({"anemia_status_at_birth": "invalid"}, index=pop_data.index)
         self.population_view.update(pop_update)
 
     def on_time_step(self, event: Event):

--- a/src/vivarium_gates_nutrition_optimization/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization/components/observers.py
@@ -39,7 +39,7 @@ class ResultsStratifier(ResultsStratifier_):
             builder,
             name="anemia_status_at_birth",
             sources=[Source("anemia_status_at_birth", SourceType.COLUMN)],
-            categories=data_values.ANEMIA_DISABILITY_WEIGHTS.keys(),
+            categories=data_values.ANEMIA_STATUS_AT_BIRTH_CATEGORIES,
         )
 
 

--- a/src/vivarium_gates_nutrition_optimization/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization/components/observers.py
@@ -35,6 +35,13 @@ class ResultsStratifier(ResultsStratifier_):
             categories=models.PREGNANCY_MODEL_STATES,
         )
 
+        self.setup_stratification(
+            builder,
+            name="anemia_status_at_birth",
+            sources=[Source("anemia_status_at_birth", SourceType.COLUMN)],
+            categories=data_values.ANEMIA_DISABILITY_WEIGHTS.keys(),
+        )
+
 
 class PregnancyObserver(DiseaseObserver):
     def __init__(self):

--- a/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
+++ b/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
@@ -123,8 +123,8 @@ class PregnantState(DiseaseState):
             index=pop_data.index,
         )
 
-class PregnancyModel(DiseaseModel):
 
+class PregnancyModel(DiseaseModel):
     def setup(self, builder: Builder):
         """Perform this component's setup."""
         super(DiseaseModel, self).setup(builder)
@@ -155,6 +155,7 @@ class PregnancyModel(DiseaseModel):
 
         builder.event.register_listener("time_step", self.on_time_step, priority=3)
         builder.event.register_listener("time_step__cleanup", self.on_time_step_cleanup)
+
 
 def Pregnancy():
     not_pregnant = NotPregnantState(models.PREGNANT_STATE_NAME)

--- a/src/vivarium_gates_nutrition_optimization/constants/data_values.py
+++ b/src/vivarium_gates_nutrition_optimization/constants/data_values.py
@@ -38,9 +38,15 @@ class _HemoglobinDistributionParameters(NamedTuple):
 
 
 HEMOGLOBIN_DISTRIBUTION_PARAMETERS = _HemoglobinDistributionParameters()
-
+ANEMIA_STATUS_AT_BIRTH_CATEGORIES = (
+    "invalid",  ## Check on anemia_status that hasn't been properly assigned
+    "not_anemic",
+    "mild",
+    "moderate",
+    "severe",
+)
 ANEMIA_DISABILITY_WEIGHTS = {
-    "none": 0.0,
+    "not_anemic": 0.0,
     "mild": 0.004,
     "moderate": 0.052,
     "severe": 0.149,

--- a/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
@@ -57,9 +57,7 @@ configuration:
         anemia:
             include:
             - 'pregnancy'
-        # disability:
-        #     include:
-        #     exclude:
-        # mortality:
-        #     include:
-        #     exclude:
+        maternal_disorders:
+            include: 'anemia_status_at_birth'
+        maternal_hemorrhage:
+            include: 'anemia_status_at_birth'

--- a/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
@@ -58,6 +58,8 @@ configuration:
             include:
             - 'pregnancy'
         maternal_disorders:
-            include: 'anemia_status_at_birth'
+            include: 
+            - 'anemia_status_at_birth'
         maternal_hemorrhage:
-            include: 'anemia_status_at_birth'
+            include: 
+            - 'anemia_status_at_birth'

--- a/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
@@ -58,8 +58,8 @@ configuration:
             include:
             - 'pregnancy'
         maternal_disorders:
-            include: 
+            include:
             - 'anemia_status_at_birth'
         maternal_hemorrhage:
-            include: 
+            include:
             - 'anemia_status_at_birth'


### PR DESCRIPTION
## Model 4.0 Observers
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc -->
Observers
- *JIRA issue*: [MIC-4301](https://jira.ihme.washington.edu/browse/MIC-4301)
- *Research reference*: <!--Link to research documentation for code -->
- https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_nutrition_optimization/pregnancies/concept_model.html#models

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Added stratification by anemia state at birth for maternal disorders and maternal hemorrhage
### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
anemia status at birth gets updated when simulants have birth (and ONLY when they have birth)
confirmed by interactive context:
`assert pop2.query("(pregnancy != 'pregnant') & (anemia_status_at_birth == 'invalid')").empty`
`assert pop2.query("(pregnancy == 'pregnant') & (anemia_status_at_birth != 'invalid')").empty`

maternal disorders + hemorrhage transitions are getting stratified by anemia status at birth
