### PR TITLE
Reformat Child Outputs

### DIFF
--- a/src/vivarium_gates_nutrition_optimization/components/children.py
+++ b/src/vivarium_gates_nutrition_optimization/components/children.py
@@ -30,7 +30,7 @@ class NewChildren:
 
     @property
     def columns_created(self):
-        return ["sex_of_child", "birth_weight"]
+        return ["sex_of_child", "birth_weight","gestational_age"]
 
     def setup(self, builder: Builder):
         self.randomness = builder.randomness.get_stream(self.name)
@@ -43,6 +43,7 @@ class NewChildren:
             {
                 "sex_of_child": models.INVALID_OUTCOME,
                 "birth_weight": np.nan,
+                "gestational_age": np.nan,
             },
             index=index,
         )
@@ -162,7 +163,7 @@ class BirthRecorder:
             "pregnancy",
             "previous_pregnancy",
             "pregnancy_outcome",
-            "pregnancy_duration",
+            "gestational_age",
             "birth_weight",
             "sex_of_child"
         ]
@@ -185,13 +186,11 @@ class BirthRecorder:
         birth_cols = {
             'sex_of_child': 'sex',
             'birth_weight': 'birth_weight',
-            'pregnancy_duration': 'gestational_age',
+            'gestational_age': 'gestational_age',
         }
 
         new_births = pop.loc[new_birth_mask, list(birth_cols)].rename(columns=birth_cols)
-        new_births['birth_date'] = datetime(2018, 12, 30)
-        # Convert gestational_age to weeks
-        new_births['gestational_age'] = new_births['gestational_age'].dt.total_seconds() / (7 * 24 * 60 * 60)
+        new_births['birth_date'] = datetime(2018, 12, 30).strftime('%Y-%m-%d T%H:%M.%f')
         self.births.append(new_births)
 
     # noinspection PyUnusedLocal
@@ -213,6 +212,7 @@ class BirthRecorder:
 
         input_draw = builder.configuration.input_data.input_draw_number
         seed = builder.configuration.randomness.random_seed
-        output_path = output_root / f"draw_{input_draw}_seed_{seed}"
+        scenario = builder.configuration.intervention.scenario
+        output_path = output_root / f'scenario_{scenario}_draw_{input_draw}_seed_{seed}'
 
         return output_path

--- a/src/vivarium_gates_nutrition_optimization/components/children.py
+++ b/src/vivarium_gates_nutrition_optimization/components/children.py
@@ -1,10 +1,9 @@
+from datetime import datetime
 from pathlib import Path
 from typing import Tuple
 
 import numpy as np
 import pandas as pd
-from datetime import datetime
-
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium_cluster_tools.utilities import mkdir
@@ -30,7 +29,7 @@ class NewChildren:
 
     @property
     def columns_created(self):
-        return ["sex_of_child", "birth_weight","gestational_age"]
+        return ["sex_of_child", "birth_weight", "gestational_age"]
 
     def setup(self, builder: Builder):
         self.randomness = builder.randomness.get_stream(self.name)
@@ -165,7 +164,7 @@ class BirthRecorder:
             "pregnancy_outcome",
             "gestational_age",
             "birth_weight",
-            "sex_of_child"
+            "sex_of_child",
         ]
         self.population_view = builder.population.get_view(required_columns)
 
@@ -184,13 +183,13 @@ class BirthRecorder:
             & (pop["pregnancy"] == models.PARTURITION_STATE_NAME)
         )
         birth_cols = {
-            'sex_of_child': 'sex',
-            'birth_weight': 'birth_weight',
-            'gestational_age': 'gestational_age',
+            "sex_of_child": "sex",
+            "birth_weight": "birth_weight",
+            "gestational_age": "gestational_age",
         }
 
         new_births = pop.loc[new_birth_mask, list(birth_cols)].rename(columns=birth_cols)
-        new_births['birth_date'] = datetime(2018, 12, 30).strftime('%Y-%m-%d T%H:%M.%f')
+        new_births["birth_date"] = datetime(2018, 12, 30).strftime("%Y-%m-%d T%H:%M.%f")
         self.births.append(new_births)
 
     # noinspection PyUnusedLocal
@@ -213,6 +212,6 @@ class BirthRecorder:
         input_draw = builder.configuration.input_data.input_draw_number
         seed = builder.configuration.randomness.random_seed
         scenario = builder.configuration.intervention.scenario
-        output_path = output_root / f'scenario_{scenario}_draw_{input_draw}_seed_{seed}'
+        output_path = output_root / f"scenario_{scenario}_draw_{input_draw}_seed_{seed}"
 
         return output_path

--- a/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
+++ b/src/vivarium_gates_nutrition_optimization/components/pregnancy.py
@@ -105,7 +105,7 @@ class PregnantState(DiseaseState):
         child_status["pregnancy_duration"] = pd.to_timedelta(
             7 * child_status["gestational_age"], unit="days"
         )
-        return child_status.drop(columns=["gestational_age"])
+        return child_status
 
     def get_dwell_time_pipeline(self, builder: Builder) -> Pipeline:
         return builder.value.register_value_producer(

--- a/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
@@ -28,6 +28,8 @@ configuration:
     interpolation:
         order: 0
         extrapolate: True
+    intervention:
+        scenario: "baseline"
     randomness:
         map_size: 1_000_000
         key_columns: ['entrance_time', 'age']


### PR DESCRIPTION
## Title: Summary, imperative, start upper case, don't end with a period
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc -->
misc
- *JIRA issue*: [MIC-4367](https://jira.ihme.washington.edu/browse/MIC-4367)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
The child HDF file from maternal model isn't quite right. For the child model to use it properly, we need to make a few changes:
Add intervention.scenario to output filename

Add birth_date  column, uniformly set to datetime '2018-12-30 T00:00.0000000'

Add column for sex of child

format  gestational_age as a float with unit of weeks

I elected to just not drop `gestational_age` in the first place from the pop table, instead of recalculating it from `pregnancy_duration` on the fly. I figure we already calculated it once, so it's just trading runtime for space, and neither seem very prohibitive here. I can change it and calculate it from `pregnancy_duration` in `children.py` if there are strong objections to this.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Sample output attached
[scenario_baseline_draw_0_seed_0.csv](https://github.com/ihmeuw/vivarium_gates_nutrition_optimization/files/12316186/scenario_baseline_draw_0_seed_0.csv)
