### PR TITLE
Remove CSMR age restrictions  

### DIFF
--- a/src/vivarium_gates_nutrition_optimization/data/loader.py
+++ b/src/vivarium_gates_nutrition_optimization/data/loader.py
@@ -67,7 +67,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.LBWSG.CATEGORIES: load_metadata,
         data_keys.LBWSG.EXPOSURE: load_lbwsg_exposure,
         data_keys.MATERNAL_DISORDERS.RAW_INCIDENCE_RATE: load_raw_incidence_data,
-        data_keys.MATERNAL_DISORDERS.CSMR: load_standard_data,
+        data_keys.MATERNAL_DISORDERS.CSMR: load_maternal_csmr,
         data_keys.MATERNAL_DISORDERS.MORTALITY_PROBABILITY: load_maternal_disorders_mortality_probability,
         data_keys.MATERNAL_DISORDERS.INCIDENT_PROBABILITY: load_pregnant_maternal_disorders_incidence,
         data_keys.MATERNAL_DISORDERS.YLDS: load_maternal_disorders_ylds,
@@ -246,6 +246,13 @@ def load_lbwsg_exposure(key: str, location: str) -> pd.DataFrame:
 # Maternal Disorders Data #
 ###########################
 
+def load_maternal_csmr(key: str, location: str) -> pd.DataFrame:
+    key = EntityKey(key)
+    entity = get_entity(key)
+    entity.restrictions.yll_age_group_id_end = 15
+    return interface.get_measure(entity, key.measure, location).droplevel("location")
+
+
 
 def load_maternal_disorders_ylds(key: str, location: str) -> pd.DataFrame:
     groupby_cols = ["age_group_id", "sex_id", "year_id"]
@@ -259,7 +266,7 @@ def load_maternal_disorders_ylds(key: str, location: str) -> pd.DataFrame:
     anemia_ylds = anemia_ylds.groupby(groupby_cols)[draw_cols].sum().reset_index()
     anemia_ylds = reshape_to_vivarium_format(anemia_ylds, location)
 
-    csmr = load_standard_data(data_keys.MATERNAL_DISORDERS.CSMR, location)
+    csmr = get_data(data_keys.MATERNAL_DISORDERS.CSMR, location)
     incidence = load_raw_incidence_data(
         data_keys.MATERNAL_DISORDERS.RAW_INCIDENCE_RATE, location
     )

--- a/src/vivarium_gates_nutrition_optimization/data/loader.py
+++ b/src/vivarium_gates_nutrition_optimization/data/loader.py
@@ -74,7 +74,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.MATERNAL_DISORDERS.RR_ATTRIBUTABLE_TO_HEMOGLOBIN: load_hemoglobin_maternal_disorders_rr,
         data_keys.MATERNAL_DISORDERS.PAF_ATTRIBUTABLE_TO_HEMOGLOBIN: load_hemoglobin_maternal_disorders_paf,
         data_keys.MATERNAL_HEMORRHAGE.RAW_INCIDENCE_RATE: load_raw_incidence_data,
-        data_keys.MATERNAL_HEMORRHAGE.CSMR: load_standard_data,
+        data_keys.MATERNAL_HEMORRHAGE.CSMR: load_maternal_csmr,
         data_keys.MATERNAL_HEMORRHAGE.INCIDENT_PROBABILITY: load_pregnant_maternal_hemorrhage_incidence,
         data_keys.MATERNAL_HEMORRHAGE.RR_ATTRIBUTABLE_TO_HEMOGLOBIN: load_hemoglobin_maternal_hemorrhage_rr,
         data_keys.MATERNAL_HEMORRHAGE.PAF_ATTRIBUTABLE_TO_HEMOGLOBIN: load_hemoglobin_maternal_hemorrhage_paf,


### PR DESCRIPTION
## Remove CSMR age restrictions  
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc -->
bugfix
- *JIRA issue*: [MIC-4266](https://jira.ihme.washington.edu/browse/MIC-4266)
- *Research reference*: <!--Link to research documentation for code -->
- https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_nutrition_optimization/pregnancies/concept_model.html

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
GBD cuts off the age range one age bin too early; I am replacing the appropriate restriction for maternal CSMRs from 14 to 15.

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Data appears in the artifact for the right age bin