### PR TITLE
Only Update Interventions Once

### DIFF
--- a/src/vivarium_gates_nutrition_optimization/components/intervention.py
+++ b/src/vivarium_gates_nutrition_optimization/components/intervention.py
@@ -51,8 +51,6 @@ class MaternalInterventions:
         self.columns_required = ["maternal_bmi_anemia_category"]
         self.columns_created = [
             "intervention",
-            "previous_on_treatment",
-            "on_treatment",
         ]
         self.population_view = builder.population.get_view(
             self.columns_required + self.columns_created + ["tracked"]
@@ -63,8 +61,6 @@ class MaternalInterventions:
             requires_columns=self.columns_required,
             requires_streams=[self.name],
         )
-        builder.event.register_listener("time_step__prepare", self.on_time_step_prepare)
-        builder.event.register_listener("time_step", self.on_time_step)
         builder.value.register_value_modifier(
             "hemoglobin.exposure",
             self.update_exposure,
@@ -82,9 +78,7 @@ class MaternalInterventions:
             pop_data.index
         )
         pop_update = pd.DataFrame(
-            {"intervention": None, 
-            "previous_on_treatment": False,
-            "on_treatment": False},
+            {"intervention": None},
             index=pop.index,
         )
         baseline_ifa = self.randomness.choice(
@@ -118,19 +112,6 @@ class MaternalInterventions:
             ) * self.ifa_effect_size
 
         return exposure
-    
-    def on_time_step_prepare(self, event):
-        prior_state_pop = self.population_view.get(event.index)
-        prior_state_pop["previous_on_treatment"] = prior_state_pop["on_treatment"]
-        self.population_view.update(prior_state_pop)
-    
-    def on_time_step(self, event):
-        pop = self.population_view.get(event.index)
-        if self.clock() - self.start_date >= timedelta(
-            days=data_values.DURATIONS.INTERVENTION_DELAY_DAYS
-        ):
-            pop["on_treatment"] = True
-            self.population_view.update(pop)
 
     def adjust_stillbirth_probability(self, index, birth_outcome_probabilities):
         pop = self.population_view.subview(["intervention"]).get(index)

--- a/src/vivarium_gates_nutrition_optimization/components/intervention.py
+++ b/src/vivarium_gates_nutrition_optimization/components/intervention.py
@@ -61,6 +61,7 @@ class MaternalInterventions:
             requires_columns=self.columns_required,
             requires_streams=[self.name],
         )
+        
         builder.value.register_value_modifier(
             "hemoglobin.exposure",
             self.update_exposure,

--- a/src/vivarium_gates_nutrition_optimization/components/intervention.py
+++ b/src/vivarium_gates_nutrition_optimization/components/intervention.py
@@ -61,7 +61,7 @@ class MaternalInterventions:
             requires_columns=self.columns_required,
             requires_streams=[self.name],
         )
-        
+
         builder.value.register_value_modifier(
             "hemoglobin.exposure",
             self.update_exposure,

--- a/src/vivarium_gates_nutrition_optimization/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization/components/observers.py
@@ -180,8 +180,8 @@ class MaternalInterventionObserver:
         for intervention in models.SUPPLEMENTATION_CATEGORIES:
             builder.results.register_observation(
                 name=f"intervention_{intervention}_count",
-                pop_filter=f'alive == "alive" and intervention == "{intervention}" and tracked == True',
-                requires_columns=["alive", "intervention"],
+                pop_filter=f'alive == "alive" and intervention == "{intervention}" and on_treatment == True and previous_on_treatment == False and tracked == True',
+                requires_columns=["alive", "intervention","on_treatment","previous_on_treatment"],
                 additional_stratifications=self.config.include,
                 excluded_stratifications=self.config.exclude,
             )


### PR DESCRIPTION
## Only Update Interventions Once
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc -->
bugfix
- *JIRA issue*: [MIC-4551](https://jira.ihme.washington.edu/browse/MIC-4551)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Overview: Currently, we update intervention observations every timestep. Let's only observe them once when treatment is first administered.

How To: change intervention component to show first transition timestep, then filter observer to that. I used an 'on_treatment' and 'previous_on_treatment' state column to do this, simuilar to diseaseobserver
### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->
Verified using interactive simulation
