### PR TITLE
IFA scenario

### DIFF
--- a/src/vivarium_gates_nutrition_optimization/components/intervention.py
+++ b/src/vivarium_gates_nutrition_optimization/components/intervention.py
@@ -78,12 +78,12 @@ class MaternalInterventions:
         pop = self.population_view.subview(["maternal_bmi_anemia_category"]).get(
             pop_data.index
         )
+        
         if self.scenario == 'ifa':
             pop_update = pd.DataFrame(
                 {"intervention": 'ifa'},
                 index=pop.index,
             )
-            self.population_view.update(pop_update)
         else:
             pop_update = pd.DataFrame(
                 {"intervention": None},
@@ -105,7 +105,8 @@ class MaternalInterventions:
 
             unsampled_ifa = pop_update["intervention"] == "maybe_ifa"
             pop_update.loc[unsampled_ifa, "intervention"] = baseline_ifa.loc[unsampled_ifa]
-            self.population_view.update(pop_update)
+
+        self.population_view.update(pop_update)
 
     def update_exposure(self, index, exposure):
         if self.clock() - self.start_date >= timedelta(

--- a/src/vivarium_gates_nutrition_optimization/data/raw_data/coverage_by_scenario.csv
+++ b/src/vivarium_gates_nutrition_optimization/data/raw_data/coverage_by_scenario.csv
@@ -2,6 +2,7 @@ scenario,normal_bmi,low_bmi
 zero_coverage,uncovered,uncovered
 baseline,maybe_ifa,maybe_ifa
 mms,mms,mms
+ifa,ifa,ifa
 universal_bep,bep,bep
 targeted_bep_no_mms,maybe_ifa,bep
 targeted_bep_mms,mms,bep

--- a/src/vivarium_gates_nutrition_optimization/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_gates_nutrition_optimization/model_specifications/branches/scenarios.yaml
@@ -7,6 +7,6 @@ branches:
         - 'zero_coverage'
         - 'baseline'
         - 'mms'
-        - 'universal_bep'
+        - 'ifa'
         - 'targeted_bep_no_mms'
         - 'targeted_bep_mms'

--- a/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
@@ -31,7 +31,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: '/mnt/team/simulation_science/costeffectiveness/artifacts/vivarium_gates_nutrition_optimization/model10.0/nigeria.hdf'
+        artifact_path: '/mnt/team/simulation_science/pub/models/vivarium_gates_nutrition_optimization/artifacts/model10.0/nigeria.hdf'
     interpolation:
         order: 0
         extrapolate: True


### PR DESCRIPTION
## IFA scenario

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-4747](https://jira.ihme.washington.edu/browse/MIC-4747)
- *Research reference*: [scenarios](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_nutrition_optimization/pregnancies/concept_model.html#id6)

### Changes and notes
Replace universal BEP with IFA scenario. Only change to intervention.py is checking if we are in IFA scenario, in which case we assign everyone to the IFA intervention. Otherwise, go through same logic as before. 

### Verification and Testing
Checked that we have everyone on IFA in IFA scenario and that this is the same way that mms behaves.
