### PR TITLE
Update pregnancy outcome observer to only record at birth

### DIFF
--- a/src/vivarium_gates_nutrition_optimization/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization/components/observers.py
@@ -170,8 +170,8 @@ class PregnancyOutcomeObserver(Component):
         for outcome in models.PREGNANCY_OUTCOMES:
             builder.results.register_observation(
                 name=f"pregnancy_outcome_{outcome}_count",
-                pop_filter=f'alive == "alive" and pregnancy_outcome == "{outcome}" and tracked == True',
-                requires_columns=["alive", "pregnancy_outcome"],
+                pop_filter=f'alive == "alive" and previous_pregnancy == "pregnant" and pregnancy == "parturition" and pregnancy_outcome == "{outcome}" and tracked == True',
+                requires_columns=["alive","previous_pregnancy", "pregnancy", "pregnancy_outcome"],
                 additional_stratifications=self.config.include,
                 excluded_stratifications=self.config.exclude,
             )

--- a/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
@@ -60,6 +60,6 @@ configuration:
         default:
             - 'age_group'
         anemia:
-            - 'pregnancy'
+            include: ['pregnancy']
         pregnancy: 
-            - 'pregnancy_outcome'
+            include: ['pregnancy_outcome']


### PR DESCRIPTION
## Update pregnancy outcome observer to only record at birth

### Description
- *Category*: feature
- *JIRA issue*: [MIC-4942](https://jira.ihme.washington.edu/browse/MIC-4942)

### Changes and notes
We'd like the pregnancy outcome observer to only record at birth instead of every time step. We can do this by only observing when the pregnancy state changes from pregnant to parturition. 

### Verification and Testing
Used pregnancy durations in interactive context to run for a few cases where count of pregnancy outcomes was known after a given number of time steps, and compared expected counts to observer output. 