### PR TITLE
count pregnancy outcomes at initialization

### DIFF
--- a/src/vivarium_gates_nutrition_optimization/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization/components/observers.py
@@ -170,18 +170,20 @@ class PregnancyOutcomeObserver(Component):
         for outcome in models.PREGNANCY_OUTCOMES:
             builder.results.register_observation(
                 name=f"pregnancy_outcome_{outcome}_count",
-                pop_filter=f'alive == "alive" and tracked == True '
-                f'and previous_pregnancy == "pregnant" and pregnancy == "parturition" '
-                f'and pregnancy_outcome == "{outcome}"',
-                requires_columns=[
-                    "alive",
-                    "previous_pregnancy",
-                    "pregnancy",
-                    "pregnancy_outcome",
-                ],
+                pop_filter=f'pregnancy_outcome == "{outcome}"',
+                aggregator=self.count_pregnancy_outcomes_at_initialization,
+                requires_columns=["pregnancy_outcome"],
                 additional_stratifications=self.config.include,
                 excluded_stratifications=self.config.exclude,
             )
+
+    ###############
+    # Aggregators #
+    ###############
+
+    def count_pregnancy_outcomes_at_initialization(self, x: pd.DataFrame) -> float:
+        breakpoint()
+        return len(x)
 
 
 class DisabilityObserver(DisabilityObserver_):

--- a/src/vivarium_gates_nutrition_optimization/components/observers.py
+++ b/src/vivarium_gates_nutrition_optimization/components/observers.py
@@ -164,6 +164,8 @@ class PregnancyOutcomeObserver(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
+        self.clock = builder.time.clock()
+        self.start_date = get_time_stamp(builder.configuration.time.start)
         self.step_size = builder.time.step_size()
         self.config = builder.configuration.stratification.pregnancy_outcomes
 
@@ -182,8 +184,10 @@ class PregnancyOutcomeObserver(Component):
     ###############
 
     def count_pregnancy_outcomes_at_initialization(self, x: pd.DataFrame) -> float:
-        breakpoint()
-        return len(x)
+        if self.clock() == self.start_date:
+            return len(x)
+        else:
+            return 0
 
 
 class DisabilityObserver(DisabilityObserver_):


### PR DESCRIPTION
## count pregnancy outcomes at initialization

### Description
- *Category*: observers
- *JIRA issue*: [MIC-4942](https://jira.ihme.washington.edu/browse/MIC-4942)

### Changes and notes
Count pregnancy outcomes only at initialization.

### Verification and Testing
Ran simulation for a few time steps and checked that 1) we recorded outcomes correctly at initialization by comparing our observer output values with a manual calculation of counts calculated in an interactive context and 2) counts don't change after initialization.  