### PR TITLE
remove dependencies on vct and vi

### DIFF
--- a/src/vivarium_gates_nutrition_optimization/components/children.py
+++ b/src/vivarium_gates_nutrition_optimization/components/children.py
@@ -1,13 +1,13 @@
+import os
 from datetime import datetime
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 import numpy as np
 import pandas as pd
 from vivarium import Component
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
-#from vivarium_cluster_tools.utilities import mkdir
 
 from vivarium_gates_nutrition_optimization.constants import (
     data_keys,
@@ -219,3 +219,28 @@ class BirthRecorder(Component):
         output_path = output_root / f"scenario_{scenario}_draw_{input_draw}_seed_{seed}"
 
         return output_path
+
+
+def mkdir(
+    path: Union[str, Path], umask: int = 0o002, exists_ok: bool = False, parents: bool = False
+) -> None:
+    """Utility method to create a directory with specified permissions.
+
+    Parameters
+    ----------
+    path
+        Path of the directory to create.
+    umask
+        Umask specifying the desired permissions - defaults to 0o002.
+    exists_ok
+        If False, raises FileExistsError if the directory already exists.
+    parents
+        If False, raises FileNotFoundError if the directory's parent doesn't exist.
+
+    """
+    path = Path(path)
+    old_umask = os.umask(umask)
+    try:
+        path.mkdir(exist_ok=exists_ok, parents=parents)
+    finally:
+        os.umask(old_umask)

--- a/src/vivarium_gates_nutrition_optimization/constants/data_values.py
+++ b/src/vivarium_gates_nutrition_optimization/constants/data_values.py
@@ -2,7 +2,6 @@ from typing import NamedTuple
 
 import numpy as np
 import pandas as pd
-#from vivarium_inputs import globals as vi_globals
 
 from vivarium_gates_nutrition_optimization.constants import data_keys, models, paths
 
@@ -20,7 +19,7 @@ class _Durations(NamedTuple):
 
 
 DURATIONS = _Durations()
-draw_count = 500
+DRAW_COUNT = 500
 
 
 INFANT_MALE_PERCENTAGES = {
@@ -107,7 +106,7 @@ PREGNANCY_CORRECTION_FACTORS = {
         paths.HEMOGLOBIN_PREGNANCY_ADJUSTMENT_FACTORS_CSV, index_col=0
     ).squeeze(),
     data_keys.HEMOGLOBIN.STANDARD_DEVIATION: pd.Series(
-        np.repeat(1.032920188, draw_count), [f"draw_{i}" for i in range(draw_count)]
+        np.repeat(1.032920188, DRAW_COUNT), [f"draw_{i}" for i in range(DRAW_COUNT)]
     ),
 }
 PROBABILITY_MODERATE_MATERNAL_HEMORRHAGE = (0.85, 0.81, 0.89)

--- a/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
+++ b/src/vivarium_gates_nutrition_optimization/model_specifications/model_spec.yaml
@@ -21,7 +21,7 @@ components:
             - ResultsStratifier()
             - PregnancyObserver()
             - PregnancyOutcomeObserver()
-#            - BirthRecorder()
+            - BirthRecorder()
             - MaternalMortalityObserver()
             - DisabilityObserver()
 #            - AnemiaObserver()


### PR DESCRIPTION
## Remove dependencies on VCT and VI
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: N/A
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
Enable BirthRecorder to be used without VCT 

### Verification and Testing
N/A
