### PR TITLE
install vbu<4.0.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,8 @@ reusable_pipeline(
       // Add additional branches for cron jobs below.
       // Note: Newly added branches will require a manual trigger of the first build 
       // for subsequent scheduled builds to run.
-      "main"
+      "main",
+      "gbd-2021",
     ],
     test_types: ["unit", "e2e"], 
     skip_doc_build: true,

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ build-env: # Create a new environment with installed packages
 	
 	conda create -n $(name) python=$(py) --yes
 # 	Bootstrap vivarium_build_utils into the new environment
-	conda run -n $(name) pip install vivarium_build_utils
+#	Pin to <4.0.0 until we update pins of packages that now exist in the monorepo
+	conda run -n $(name) pip install "vivarium_build_utils<4.0.0"
 #	Install packages based on type
 	@if [ "$(type)" = "simulation" ]; then \
 		conda run -n $(name) make install ENV_REQS=dev; \

--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,11 @@ build-env: # Create a new environment with installed packages
 	
 	conda create -n $(name) python=$(py) --yes
 # 	Bootstrap vivarium_build_utils into the new environment
-#	Pin to <4.0.0 until we update pins of packages that now exist in the monorepo
-	conda run -n $(name) pip install "vivarium_build_utils<4.0.0"
+# 	Bootstrap vivarium_build_utils into the new environment.
+# 	Pin to <=3.3.2 until this model repo's deps are migrated to the post-monorepo names
+# 	NOTE: v3.3.3 / v3.3.4 are post-archive sunset releases of the standalone vbu repo that
+#		were never tagged in the monorepo, so the Jenkins shared library loader can't find them
+	conda run -n $(name) pip install "vivarium_build_utils<=3.3.2"
 #	Install packages based on type
 	@if [ "$(type)" = "simulation" ]; then \
 		conda run -n $(name) make install ENV_REQS=dev; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,24 @@
+# Minimal [project] block so vivarium_build_utils' base.mk can parse the
+# distribution name from pyproject.toml instead of falling back to
+# ``$(notdir $(CURDIR))`` (which is unsafe under Jenkins's parallel
+# workspaces - directories like ``<repo>@2`` contain ``@``, which uv
+# rejects in ``--config-settings-package`` values). Every other PEP 621
+# field is still set in setup.py; setuptools requires anything outside
+# [project] but set via setup() to be declared dynamic.
+[project]
+name = "vivarium_gates_nutrition_optimization"
+dynamic = [
+    "version",
+    "description",
+    "readme",
+    "license",
+    "authors",
+    "urls",
+    "dependencies",
+    "optional-dependencies",
+    "scripts",
+]
+
 [tool.black]
 line_length = 94
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,10 @@ if __name__ == "__main__":
         "gbd_mapping>=3.1.1,<5.0.0",
         "vivarium>=4.1.0,<5.0.0",
         "vivarium_public_health>=5.1.5,<6.0.0",
+        # Pin to <=3.3.2 until this model repo's deps are migrated to the post-monorepo names
+        # NOTE: v3.3.3 / v3.3.4 are post-archive sunset releases of the standalone vbu repo that
+        #   were never tagged in the monorepo, so the Jenkins shared library loader can't find them
+        "vivarium_build_utils<=3.3.2",
         "click",
         "jinja2",
         "loguru",

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ if __name__ == "__main__":
     ]
 
     setup(
-        name=about["__title__"],
+        # name is declared statically in pyproject.toml's [project] block.
+        # Setuptools errors if it's also passed here.
         version=about["__version__"],
         description=about["__summary__"],
         long_description=long_description,
@@ -95,8 +96,9 @@ if __name__ == "__main__":
             "dev": test_requirements + cluster_requirements + lint_requirements,
         },
         zip_safe=False,
-        entry_points="""
-            [console_scripts]
-            make_artifacts=vivarium_gates_nutrition_optimization.tools.cli:make_artifacts
-        """,
+        entry_points={
+            "console_scripts": [
+                "make_artifacts=vivarium_gates_nutrition_optimization.tools.cli:make_artifacts",
+            ],
+        },
     )


### PR DESCRIPTION
## install vbu<4.0.0

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, data artifact, implementation, observers,
                   post-processing, refactor, revert, test, release, other/misc --> other
- *JIRA issue*: [MIC-7261](https://jira.ihme.washington.edu/browse/MIC-7261)
- *Research reference*: <!--Link to research documentation for code -->

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

Some of the dependencies (e.g. vivarium and possibly others) are pinned
to pre-monorepo versions which in turn pin vbu to its pre-monorepo version.
Until we update all pins to pre-monorepo version, just pin vbu down.

Ironically, vbu shouldn't even be getting pinned in the first place since it's
not used directly by the actual code base - it's only used in the makefile.
An alternative - and arguably better - solution here is to remove the vbu pin
from all framework repos!

### Verification and Testing
<!--
Details on how code was verified. Consider: plots, images, (small) csv files.
-->

